### PR TITLE
new command \includedot

### DIFF
--- a/dot2texi.sty
+++ b/dot2texi.sty
@@ -307,7 +307,7 @@
             {Please convert \dtt@figname.dot manually}}
 }
 
-\newcommand\includedottex[2][]{%
+\newcommand\includedot[2][]{%
 	\noexpandarg%
 	\expandafter\StrSubstitute\expandafter{#2}{./}{_}[\x]%
 	\expandafter\StrSubstitute\expandafter{\x}{/}{_}[\x]%


### PR DESCRIPTION
for including external dot files.

The auxiliary tex file names depend on the corresponding dot file's path.
Slashes in the path are replaced by underscores, to map dot files directly to tex files, therefore avoid issues caused by the fignum counter when \includeonly is used.

A new option "force" enables forcing dot2tex to convert the dot file, even if the output tex file is newer, so that changes in \includedottex command options can become effective.

Relevant discussion in #3.
