### PR TITLE
Ugly workaround for latex -outdir

### DIFF
--- a/dot2texi.sty
+++ b/dot2texi.sty
@@ -102,6 +102,8 @@
 % Option for setting an output directory
 \DeclareOptionX{outputdir}[]{\def\dtt@outputdir{#1}}
 \def\dtt@outputdir{}
+\DeclareOptionX{inputdir}[]{\def\dtt@inputdir{#1}}
+\def\dtt@inputdir{}
 \DeclareOptionX{debug}{\dtt@debugtrue}
 
 \newcommand\setoutputdir[1]{\def\dtt@outputdir{#1}}
@@ -292,7 +294,7 @@
                 \dtt@mathmode\space
                 \dtt@graphstyle\space
                 \dtt@cacheopt\space
-                -o \dtt@figname.tex \dtt@options\space \dtt@figname.dot}
+                -o \dtt@inputdir\dtt@figname.tex \dtt@options\space \dtt@inputdir\dtt@figname.dot}
             \IfFileExists{\dtt@figname.tex}{%
                 \PackageInfo{dot2texo}{\dtt@figname.dot converted}
             }


### PR DESCRIPTION
As mentioned by [this issue](https://github.com/kjellmf/dot2tex/issues/52), dot2tex fails when the tex document is compiled with a ```-outdir``` CLI switch because it is not informed that the ```.dot``` file was output in a different place, as dot2texi ```\write```s will implicitly go there. This ugly hack allows to load dot2texi with a ```[inputdir=./build/]``` option that should be set to match the latex ```-outdir```.

I do not know if there is a TeX primitive that is set to the oudir; I could not find one.